### PR TITLE
allow for theme packages that dont start with aglio-theme

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -52,7 +52,10 @@ exports.collectPathsSync = (input, includePath) ->
 # Get the theme module for a given theme name
 exports.getTheme = (name) ->
     name = 'olio' if not name or name in LEGACY_TEMPLATES
-    require "aglio-theme-#{name}"
+    try
+        require "aglio-theme-#{name}"
+    catch
+        require name
 
 # Render an API Blueprint string using a given template
 exports.render = (input, options, done) ->


### PR DESCRIPTION
this allows for 2 new use cases:
- private npm packages to be used e.g. @username/aglio-theme-name
- themes that don't have the aglio-theme- prefix
